### PR TITLE
Update ObjectInspector.js

### DIFF
--- a/src/ObjectInspector.js
+++ b/src/ObjectInspector.js
@@ -59,7 +59,9 @@ export default class ObjectInspector extends Component {
   }
 
   componentWillMount(){
-    React.initializeTouchEvents(true);
+    if (typeof React.initializeTouchEvents === 'function') {
+      React.initializeTouchEvents(true);
+    }
   }
 
   render() {


### PR DESCRIPTION
initializeTouchEvents deprecated in React@0.14
