### PR TITLE
remove the onTouchStart event handler

### DIFF
--- a/src/ObjectInspector.js
+++ b/src/ObjectInspector.js
@@ -95,7 +95,7 @@ export default class ObjectInspector extends Component {
 
     return (
       <div className="ObjectInspector">
-        <span className="ObjectInspector-property" onTouchStart={this.handleClick.bind(this)} onClick={this.handleClick.bind(this)}>
+        <span className="ObjectInspector-property" onClick={this.handleClick.bind(this)}>
           <span className="ObjectInspector-expand-control ObjectInspector-unselectable">{expandGlyph}</span>
           {(() => {
             if (typeof name !== 'undefined') {


### PR DESCRIPTION
When a user touches the screen of mobile devices, events - touchstart, tauchend, click - occurs. the present code has two event handlers - touchstart and click - so these two handlers crash. tree is opened by onTouchStart when the user taps the tree to see sub-object and is closed by onClick as it is called then. I have deleted onTouchStart and checked that it works well.
