### PR TITLE
Updated peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "webpack-dev-server": "^1.8.2"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+   "react": "^0.14.0 || ^16.0.0"
   }
 }


### PR DESCRIPTION
every time we are trying to work with it causes a warning -
warning " > react-object-inspector@0.2.1" has incorrect peer dependency "react@^0.14.0".